### PR TITLE
Add cmdlet to build repos with bxl and configure orchard(s) and roslyn

### DIFF
--- a/projects/sdk/working/orchard-core/repoInfo
+++ b/projects/sdk/working/orchard-core/repoInfo
@@ -1,5 +1,5 @@
 {
-    "RepoAddress": "https://github.com/OrchardCMS/OrchardCore.git",
-    "RepoLocation": "811b5d1c2fc0311a9d2546e51b351be22cd5da04",
+    "RepoAddress": "https://github.com/smera/OrchardCore.git",
+    "RepoLocation": "cc3f919e2b216aa1e8ef537a768bf0a0fcd235f4",
     "SolutionFile": "OrchardCore.sln"
 }

--- a/projects/sdk/working/orchard-core/repoInfo
+++ b/projects/sdk/working/orchard-core/repoInfo
@@ -1,5 +1,5 @@
 {
     "RepoAddress": "https://github.com/smera/OrchardCore.git",
-    "RepoLocation": "cc3f919e2b216aa1e8ef537a768bf0a0fcd235f4",
+    "RepoLocation": "dev",
     "SolutionFile": "OrchardCore.sln"
 }

--- a/projects/sdk/working/orchard/repoInfo
+++ b/projects/sdk/working/orchard/repoInfo
@@ -1,5 +1,5 @@
 {
-    "RepoAddress": "https://github.com/OrchardCMS/Orchard.git",
-    "RepoLocation": "c491990a0e05cefff2606171cc7dba70283b478f",
+    "RepoAddress": "https://github.com/smera/Orchard.git",
+    "RepoLocation": "83af67bf7e5ee40388470eadf8fe38449863f913",
     "SolutionFile": "src/Orchard.sln"
 }

--- a/projects/sdk/working/orchard/repoInfo
+++ b/projects/sdk/working/orchard/repoInfo
@@ -1,5 +1,5 @@
 {
     "RepoAddress": "https://github.com/smera/Orchard.git",
-    "RepoLocation": "83af67bf7e5ee40388470eadf8fe38449863f913",
+    "RepoLocation": "dev",
     "SolutionFile": "src/Orchard.sln"
 }

--- a/projects/sdk/working/roslyn.bxl/repoInfo
+++ b/projects/sdk/working/roslyn.bxl/repoInfo
@@ -1,0 +1,5 @@
+{
+    "RepoAddress": "https://github.com/smera/roslyn.git",
+    "RepoLocation": "staticGraph",
+    "SolutionFile": "Compilers.sln"
+}

--- a/projects/sdk/working/roslyn.bxl/setup.ps1
+++ b/projects/sdk/working/roslyn.bxl/setup.ps1
@@ -1,0 +1,8 @@
+param(
+    [string]$repoDirectory,
+    [string]$solutionFile
+    )
+
+$env:Path = "$env:MSBuildBootstrapBinDirectory;$env:Path"
+
+& "$repoDirectory\Restore.cmd"

--- a/scripts/BuildXL.ps1
+++ b/scripts/BuildXL.ps1
@@ -1,0 +1,31 @@
+# projectRoot is expected to be a path to the project info to build. E.g. projects/sdk/roslyn.bxl
+# pathToBxl is the path to bxl.exe
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$projectRoot,
+    [Parameter(Mandatory=$true)]
+    [string]$pathToBxl
+)
+
+# set up the environment
+$setupEnv = $PSScriptRoot + "\BuildRepos.ps1 RedirectEnvironmentToBuildOutputs"
+Invoke-Expression $setupEnv
+
+. "$PSScriptRoot\Common.ps1"
+
+# look for a repo on the given path
+$repoInfo = GetRepoInfo $projectRoot
+
+if ($null -eq $repoInfo.RepoDirectory) {
+    Write-Host "Could not find repo:" $projectRoot
+    exit 1
+}
+
+# Materialize and setup the repo
+MaterializeRepoIfNecessary $repoInfo
+RunProjectSetupIfPresent $projectRoot $repoInfo
+
+# Run bxl
+Write-Information "Running bxl"
+$pathToConfig = $repoInfo.RepoDirectory + "\config.dsc"
+& $pathToBxl /c:$pathToConfig /disableProcessRetryOnResourceExhaustion+

--- a/scripts/BuildXL.ps1
+++ b/scripts/BuildXL.ps1
@@ -8,8 +8,9 @@ param (
 )
 
 # set up the environment
-$setupEnv = $PSScriptRoot + "\BuildRepos.ps1 RedirectEnvironmentToBuildOutputs"
-Invoke-Expression $setupEnv
+Write-Host "Setting up the environment..."
+& "$PSScriptRoot\BuildRepos.ps1" -configuration "Release" -RedirectEnvironmentToBuildOutputs
+Write-Host "Using MSBuild at " $env:MSBuildBootstrapBinDirectory
 
 . "$PSScriptRoot\Common.ps1"
 
@@ -22,10 +23,10 @@ if ($null -eq $repoInfo.RepoDirectory) {
 }
 
 # Materialize and setup the repo
-MaterializeRepoIfNecessary $repoInfo
+MaterializeRepoIfNecessary $repoInfo $projectRoot
 RunProjectSetupIfPresent $projectRoot $repoInfo
 
 # Run bxl
-Write-Information "Running bxl"
+Write-Host "Running bxl"
 $pathToConfig = $repoInfo.RepoDirectory + "\config.dsc"
 & $pathToBxl /c:$pathToConfig /disableProcessRetryOnResourceExhaustion+

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -153,12 +153,12 @@ function MaterializeRepo([PSCustomObject] $repoInfo, [string] $repoRoot)
     CloneOrUpdateRepo $repoAddress $repoCommit $repoDirectory
 }
 
-function MaterializeRepoIfNecessary([PSCustomObject]$repoInfo)
+function MaterializeRepoIfNecessary([PSCustomObject]$repoInfo, [string] $repoRoot)
 {
     if ($null -ne $repoInfo.RepoAddress)
     {
         Write-Information "Materializing $($repoInfo.RepoAddress)"
-        MaterializeRepo $repoInfo $projectRoot
+        MaterializeRepo $repoInfo $repoRoot
     }
 }
 

--- a/scripts/Test.ps1
+++ b/scripts/Test.ps1
@@ -57,7 +57,7 @@ function TestProject([string] $projectRoot, [string] $projectExtension)
     Write-Information "RepoInfo object:"
     Write-Information $repoInfo
 
-    MaterializeRepoIfNecessary $repoInfo
+    MaterializeRepoIfNecessary $repoInfo $projectRoot
 
     $solutionFile = if ($null -ne $repoInfo.SolutionFile)
     {


### PR DESCRIPTION
* Add BuildXL.ps1 to build an individual MSBuild-based repo with bxl
* Configure Orchard, OrchardCore and Roslyn to point to forks that contain the associated main bxl config file and solution-equivalent traversal projects
* Factor out some common logic to common.ps1 that now both Test.ps1 and BuildXL.ps1 are using